### PR TITLE
feat: support multiple discord roleIds as staff

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,9 @@ Config = {
     Debug = true,
     UseDiscordRestAPI = true,      -- Replaces the ACE Permission System with one relying on the Discord REST API where players get their permissions based on their roles, make sure to configure the bot token and guild id in sv_config.lua
     AcePerm = "vadmin.staff",      -- Uses the Deafult ACE Permission System, only works if you don't UseDiscordRestAPI set to true.
-    RoleID = "839129247918194732", -- Only Used ff UseDiscordRestAPI is set to true.
+    RoleID = {                     -- Only Used ff UseDiscordRestAPI is set to true. Add multiple roles below
+        ["839129247918194732"] = true
+    },
     ReportCommand = "report",      -- The name of the report command for normal players.
     ReportMenuCommand = "reports", -- The name of the command to open the reports menu for staff members.
 }

--- a/server/classes/CPlayer.lua
+++ b/server/classes/CPlayer.lua
@@ -29,7 +29,7 @@ function CPlayer:new(player)
         if discordRoles then
             for i = 1, #discordRoles do
                 local discordRoleId = discordRoles[i]
-                if discordRoleId == Config.RoleID then
+                if Config.RoleID[discordRoleId] then
                     isStaff = true
                     OnlineStaff[tonumber(player)] = {
                         id = player,


### PR DESCRIPTION
By storing roleIDs as a table and then checking if a roleId is present in the table we can support multiple roleIds to authenticate as staff.